### PR TITLE
Cekabsensi: integrate holiday API to skip on holiday

### DIFF
--- a/controllers/main.py
+++ b/controllers/main.py
@@ -166,6 +166,11 @@ def loop_updates(updates):
             processed.append(item['message']['message_id'])
             process_telegram_input(item)
 
+def is_today_holiday():
+    """ simple wrapper for groupware.check_date_is_holiday() """
+    auth_token = user.get_user_token(os.getenv('TEST_USER'))
+    return groupware.check_date_is_holiday(auth_token)
+
 if __name__ == '__main__':
     import sys
     sleep_interval = 3 if len(sys.argv) < 2 else sys.argv[1]

--- a/server.py
+++ b/server.py
@@ -31,6 +31,10 @@ async def process_telegram(request: Request, background_tasks: BackgroundTasks, 
 async def cek_absensi(request: Request, background_tasks: BackgroundTasks, token=None):
     verify_token(token)
 
+    # if today is a holiday, skip
+    if main_controller.is_today_holiday():
+        return 'ok'
+
     data = {
         'message' : {
             'chat': {


### PR DESCRIPTION
hanya digunakan untuk endpoint `/cekabsensi` (yang dipanggil oleh scheduler). menambahkan pengecekan di endpoint tersebut, ketika tanggal hari ini muncul di list API holiday groupware tahun ini, maka proses akan dilewat. adapun pemanggilan dengan command telegram `/cekabsensi` tetap bisa dilakukan