### PR TITLE
Fix error on /lapor command when lampiran is empty

### DIFF
--- a/models/bot.py
+++ b/models/bot.py
@@ -143,7 +143,7 @@ def process_report(telegram_item, input_fields, image_data, peserta=None, save_h
         'isMainTask' : 'null',
         'isDocumentLink' : 'true',
         'workPlace' : 'WFH',
-        'documentTask': 'null',
+        'documentTask': '',
     }
     for field in defaults_values:
         if field not in fields:


### PR DESCRIPTION
Caused by invalid default lampiran value, which 'null' is no longer a valid value.

ClickUp: https://app.clickup.com/t/83ucbb