### PR TITLE
Ulangtahun: add env var to exclude declared usernames

### DIFF
--- a/example.env
+++ b/example.env
@@ -49,3 +49,6 @@ TOKEN_SECRET=12356
 
 # telegram photo file_id used for functional testing
 # TEST_PHOTO_FILE_ID=123
+
+# list of user to be excluded from `/ulangtahun` command. use groupware username (usually taken from gmail account). separate each accounts with semicolon (';')
+# ULANGTAHUN_EXCLUDE_USERNAME=

--- a/models/user.py
+++ b/models/user.py
@@ -138,11 +138,15 @@ def get_users_by_birthday(compare_date):
     ALIAS_INV = {v:k for k, v in ALIAS.items()}
     list_birthday = []
 
+    EXCLUDE_USERNAMES = os.getenv('ULANGTAHUN_EXCLUDE_USERNAMES', '').split(';')
+
     for item in groupware.get_users(auth_token, is_active=True, struktural=False):
         birthday = datetime.datetime.strptime(item['birth_date'], '%Y-%m-%d')
         username = item['username']
 
-        if birthday.month == compare_date.month and birthday.day == compare_date.day :
+        if birthday.month == compare_date.month \
+        and birthday.day == compare_date.day \
+        and username not in EXCLUDE_USERNAMES:
             list_birthday.append([
                 item['fullname'],
                 item['divisi'] ,


### PR DESCRIPTION
Request from @yohang88 , there were some of our friends whom wishes that their name not included in our daily automatic `/ulangtahun` command. I added a new `ULANGTAHUN_EXCLUDE_USERNAMES` env var to exclude those people