### PR TITLE
Groupware: fix struktural filtering in get_users()

### DIFF
--- a/models/groupware.py
+++ b/models/groupware.py
@@ -94,7 +94,7 @@ def get_attendance(auth_token, date=None):
     raw_response = req.json()
     return raw_response['results']
 
-def get_users(auth_token, is_active=True, struktural=False, search=None):
+def get_users(auth_token, is_active=True, with_struktural=False, search=None):
     """ get list of all users which match parameters """
     headers = {
         'Authorization': 'Bearer ' + auth_token,
@@ -106,7 +106,6 @@ def get_users(auth_token, is_active=True, struktural=False, search=None):
             'page_size' : 300,
             'page': 1,
             'is_active' : 'true' if is_active else None,
-            'struktural' : 'true' if struktural else None,
             'search' : search,
         },
         headers=headers
@@ -116,7 +115,11 @@ def get_users(auth_token, is_active=True, struktural=False, search=None):
         raise Exception('Error response: ' + req.text)
 
     raw_response = req.json()
-    return raw_response['results']
+    results = raw_response['results'] \
+        if with_struktural else \
+        [ i for i in raw_response['results'] if i['divisi'] != 'ASN' ]
+
+    return results
 
 def check_date_is_holiday(auth_token, date=None):
     """ check the given date is a holiday

--- a/models/user.py
+++ b/models/user.py
@@ -113,7 +113,7 @@ def get_users_attendance(date=None):
     ]
 
     results= []
-    for item in groupware.get_users(auth_token, is_active=True, struktural=False):
+    for item in groupware.get_users(auth_token, is_active=True, with_struktural=False):
         username = item['username']
         if username in PASSWORD :
             results.append([
@@ -140,7 +140,7 @@ def get_users_by_birthday(compare_date):
 
     EXCLUDE_USERNAMES = os.getenv('ULANGTAHUN_EXCLUDE_USERNAMES', '').split(';')
 
-    for item in groupware.get_users(auth_token, is_active=True, struktural=False):
+    for item in groupware.get_users(auth_token, is_active=True, with_struktural=False):
         birthday = datetime.datetime.strptime(item['birth_date'], '%Y-%m-%d')
         username = item['username']
 


### PR DESCRIPTION
Rekues baru dari kang rizki adam agar kedepannya user pegawai JDS yang ASN bisa submit evidence via telegram, tapi tetap jangan dimunculkan di command `/cekabsensi`. Setaelah dilihat lagi sebenarnya harusnya fitur `/cekabsensi` sudah melakukan filter agar yang diperhitungkan hanya user non-ASN, namun ternyata ada kendala di implementasi fungsi `get_users()` di model groupware.

Di Implementasi yang lama fitur ini hanya mengandalkan parameter `struktural` dari API groupware digiteam. Namun ternyata ketika di set `struktural = false`, endpoint yang dimaksud akan tetap mengembalikan semua user termasuk user yang ASN. solusi yang dipilih akhirnya adalah melakukan filter tambahan berdasakan divisi user yang bersangkutan

## Evidence

- title: Perbaikan filtering ASN di fitur cekabsensi bot telegram
- project: Digiteam
- participants: @azophy @firmanJS 
