### PR TITLE
Add validation in set_alias() method to avoid alias conflict

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -50,6 +50,9 @@ def set_alias(username, new_alias):
 
     print('set alias for : username', username, 'new_alias', new_alias)
 
+    if new_alias in ALIAS:
+        return(False, f"Maaf, sudah ada user '{ALIAS[new_alias]}' dengan alias '{new_alias}'. Mohon ubah dahulu alias yang lama agar tidak terjadi bentrok alias, kemudian lakukan reload_data")
+
     query_find_user = """
         SELECT username
         FROM users


### PR DESCRIPTION
Saat ini kalau misalnya kita memanggil fungsi `/setalias` dengan nama alias yang sama, hal ini akan mengakibatkan 2 user dengan nama alias yang sama. Tentu hal ini tidak diinginkan karena seharusnya hubungan antara alias telegram dengan username digiteam berlaku 1-1. MR ini menambahkan validasi baru untuk mencegah hal ini

## Evidence

- title: Perbaikan validasi untuk mencegah konflik di fitur setalias bot telegram
- project: Digiteam
- participants: @azophy @firmanJS 
