### PR TITLE
Set default username for checkin & checkout command

### DIFF
--- a/controllers/checkin.py
+++ b/controllers/checkin.py
@@ -23,11 +23,17 @@ def action_checkin(item, peserta=None):
     lines = input_text.split("\n")
     first_params = lines[0]
     first_params = first_params[first_params.find(' ')+1 :] # start from after first ' '
+
+    # default values
+    username = '@' + item['message']['from']['username']
+    location = first_params.upper()
+
+    # custom values
     first_params = first_params.split('|') # split with '|'
 
-    if len(first_params) != 2 :
-        bot.process_error(item, 'Wrong format')
-        return
+    if len(first_params) == 2 :
+        username = first_params[0].strip()
+        location = first_params[1].strip().upper()
 
     current_time = datetime.now(timezone('Asia/Jakarta'))
     current_time_utc = current_time.astimezone(timezone('UTC'))
@@ -35,9 +41,6 @@ def action_checkin(item, peserta=None):
     checkinDateTimeFormat = current_time_utc.strftime('%Y-%m-%dT%H:%M:%I.000Z')
     dateNow   = current_time.strftime('%Y-%m-%d')
     hourMinuteNow = current_time.strftime('%H:%M')
-
-    username = first_params[0].strip()
-    location = first_params[1].strip().upper()
 
     locationAvailable = ['WFH','WFO','PERJADIN']
 
@@ -64,11 +67,11 @@ def action_checkin(item, peserta=None):
         responseMessage = json.loads(req.text)
 
         if req.status_code >= 300:
-            errors = "%s | Checkin Gagal | %s %s " % (username, responseMessage["message"], bot.EMOJI_FAILED)
-            return bot.process_error(item, errors)
+            e = ValueError("%s | Checkin Gagal | %s %s " % (username, responseMessage["message"], bot.EMOJI_FAILED))
+            return bot.process_error(item, e)
         else:
             return bot.reply_message(item, msg)
-    
+
     else:
         msg = "Checkin gagal | Jenis kehadiran anda tidak sesuai"
         return bot.reply_message(item, msg)

--- a/controllers/checkout.py
+++ b/controllers/checkout.py
@@ -20,14 +20,15 @@ def action_checkout(item):
     elif 'text' in item['message']:
         input_text = item['message']['text']
 
+    # default values
+    username = '@' + item['message']['from']['username']
+
     lines = input_text.split("\n")
     first_params = lines[0]
-    first_params = first_params[first_params.find(' ')+1 :] # start from after first ' '
-    first_params = first_params.split('|') # split with '|'
+    if ' ' in first_params:
+        first_params = first_params[first_params.find(' ')+1 :] # start from after first ' '
 
-    if len(first_params) != 1 :
-        bot.process_error(item, 'Wrong format')
-        return
+        username = first_params.strip()
 
     current_time = datetime.now(timezone('Asia/Jakarta'))
     current_time_utc = current_time.astimezone(timezone('UTC'))
@@ -35,8 +36,6 @@ def action_checkout(item):
     checkoutDateTimeFormat = current_time_utc.strftime('%Y-%m-%dT%H:%M:%I.000Z')
     dateNow   = current_time.strftime('%Y-%m-%d')
     hourMinuteNow = current_time.strftime('%H:%M')
-
-    username = first_params[0].strip()
 
     data = {
         'date': checkoutDateTimeFormat,
@@ -56,7 +55,7 @@ def action_checkout(item):
     responseMessage = json.loads(req.text)
 
     if req.status_code >= 300:
-        errors = "%s | Checkout Gagal | %s %s " % (username, responseMessage["message"], bot.EMOJI_FAILED)
-        return bot.process_error(item, errors)
+        e = ValueError("%s | Checkout Gagal | %s %s " % (username, responseMessage["message"], bot.EMOJI_FAILED))
+        return bot.process_error(item, e)
     else:
         return bot.reply_message(item, msg)

--- a/controllers/help.py
+++ b/controllers/help.py
@@ -68,17 +68,25 @@ daftar peserta dipisahkan dengan spasi atau koma
 """
 
 msg['checkin'] = """
-Cara menggunakan command `/checkin`:
+Cara menggunakan command `/checkin` untuk user telegram yang bersangkutan:
 ```
-/checkin <username atau alias> | <lokasi>
+/checkin <lokasi>
+```
+atau jika ingin checkin untuk user lain
+```
+/checkin <peserta> | <lokasi>
 ```
 contoh: `/checkin @fulan | WFH`
 """
 
 msg['checkout'] = """
-Cara menggunakan command `/checkout`:
+Cara menggunakan command `/checkout` untuk user telegram yang bersangkutan:
 ```
-/checkout <username atau alias>
+/checkout
+```
+atau jika ingin checkout untuk user lain
+```
+/checkout <peserta>
 ```
 """
 

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -44,11 +44,10 @@ def action_whatsnew(telegram_item):
     """ action for /whatsnew command """
     # banyak karakter yang perlu di escape agar lolos parsing markdown di telegram. ref: https://core.telegram.org/bots/api#markdownv2-style
     msg = """\#UPDATERILIS
-Per tanggal 27 April 2021, kamu bisa menggunakan command terbaru yaitu
+Per tanggal 26 November 2021, ada beberapa perubahan:
 
-`/ulangtahun`
-
-Untuk mengetahui karyawan JDS yang ulang tahun hari ini\. Command ini pun akan otomatis muncul setiap harinya melalui bantuan bot digiteam\.
+\- Perbaikan command `/setalias`\. Untuk mencegah konflik dari alias yang sama, sekarang akan muncul pesan error jika kamu mencoba mendaftarkan user alias yang sudah ada sebelumnya\.
+\- Untuk command `/checkin` dan `/checkout` sekarang secara default akan menggunakan akun user yang mengirimkan command tersebut, sehingga kamu tidak perlu menyebutkan user kamu sendiri\.
 """
     return bot.reply_message(telegram_item, msg, is_markdown=True)
 


### PR DESCRIPTION
Di versi sebelumnya kalau menggunakan command `/checkin` dan `/checkout` tetap harus menyantumkan nama akun telegram kita sendiri. Di MR ini ditambahkan nilai otomatis sehingga ketika username dikosongkan akan otomatis menggunakan username dari user yang mengirimkan command tersebut 

## Evidence

- title: Setting username default di fitur checkin & checkout bot telegram
- project: Digiteam
- participants: @azophy @firmanJS 
