### PR TITLE
add checkin emot mood default set neutral

### DIFF
--- a/controllers/checkin.py
+++ b/controllers/checkin.py
@@ -51,6 +51,7 @@ def action_checkin(item, peserta=None):
             'location': location,
             'message': "HADIR",
             'note': "",
+            'mood': "neutral"
         }
 
         getToken = user.get_user_token(username)


### PR DESCRIPTION
# Overview

- add checkin emot mood default set neutral

cc: @jabardigitalservice/jds-backend 

## Evidence
- title: add checkin via bot set emot mood default neutral
- project: DigiTeam
- participants: @ayocodingit @azophy 